### PR TITLE
ensure that running builds are not cancelled

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -12,7 +12,7 @@
     <category>tools</category>
     <bugs>https://github.com/nextcloud/droneci_fast_lane</bugs>
     <dependencies>
-        <nextcloud min-version="24" max-version="25"/>
+        <nextcloud min-version="24" max-version="26"/>
     </dependencies>
     <commands>
 		<command>OCA\DroneciFastLane\Command\BuildPrioritize</command>

--- a/lib/Service/Prioritization.php
+++ b/lib/Service/Prioritization.php
@@ -84,6 +84,7 @@ class Prioritization {
 		foreach ($buildQueueGen as $build) {
 			if (isset($prioritizedBuilds[$build->uniqueName()])
 				|| $build->getCreatedAt() > $oldestPrioBuildTime
+				|| $build->getStatus() === Drone::BUILD_STATUS_RUNNING
 			) {
 				continue;
 			}

--- a/tests/Unit/Service/PrioritizationTest.php
+++ b/tests/Unit/Service/PrioritizationTest.php
@@ -159,13 +159,15 @@ class PrioritizationTest extends TestCase {
 
 	public function testReorganizeQueue(): void {
 		$droneBuildList = [
-			$this->makeDroneBuild(1200),  // restart
+			$this->makeDroneBuild(1200),  // leave as running
 			$this->makeDroneBuild(1201),  // restart
+			$this->makeDroneBuild(1202),  // restart
 			$this->makeDroneBuild(1203),  // prio
 			$this->makeDroneBuild(1205),  // leave
 		];
+		$droneBuildList[0]->setStatus(Drone::BUILD_STATUS_RUNNING);
 
-		$prioBuildList = [BasicBuild::fromDerivedBuild($droneBuildList[2])];
+		$prioBuildList = [BasicBuild::fromDerivedBuild($droneBuildList[3])];
 
 		$this->mapper->expects($this->once())
 			->method('getBuilds')


### PR DESCRIPTION
Builds that are running (and might even be in an advanced state) should not be restarted even when a prioritizied build is behind them. It's actually what is advertised, but the check was in fact missing.