### PR TITLE
fix(Drone): fix broken list when stored build is unavailable

### DIFF
--- a/lib/Service/Drone.php
+++ b/lib/Service/Drone.php
@@ -136,6 +136,11 @@ class Drone {
 			$buildItem = json_decode($response->getBody(), true, 512, JSON_THROW_ON_ERROR);
 			return $this->buildItemToObject($buildItem, $namespace, $repo);
 		} catch (Exception $e) {
+			if ($e->getCode() === 404) {
+				$build = new DroneBuild();
+				$build->setStatus('x_expired');
+				return $build;
+			}
 			throw new RuntimeException('Error while getting build list', $e->getCode(), $e);
 		}
 	}

--- a/lib/Service/Prioritization.php
+++ b/lib/Service/Prioritization.php
@@ -61,7 +61,7 @@ class Prioritization {
 			$build = $this->drone->getBuildInfo($buildNumber, $namespace, $repo);
 			$prioBuild = BasicBuild::fromDerivedBuild($build);
 			$this->mapper->insert($prioBuild);
-		} catch (RuntimeException|Exception $e) {
+		} catch (RuntimeException|Exception) {
 			return false;
 		}
 
@@ -106,7 +106,7 @@ class Prioritization {
 
 	/**
 	 * @return Generator<string, DroneBuild>
-	 * @throws Exception
+	 * @throws RuntimeException
 	 */
 	public function getQueue(): Generator {
 		$storedBuilds = $this->mapper->getBuilds();


### PR DESCRIPTION
DroneCI replies with a 404 when a build is not in the list anymore. So we return an empty BuildInfo object with a custom status.

What is still missing is a cleanup of the DB table with prioritized builds.